### PR TITLE
Remove `clean` from default maven goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Don't run `mvn clean` by default. ([#4](https://github.com/cucumber/action-publish-mvn/pull/4))
+
 ## [1.1.0] - 2022-03-14
 ### Changed
 - Skip integration tests ([#3](https://github.com/cucumber/action-publish-mvn/pull/3))

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Needs Java to be installed first.
 * `nexus-username`
 * `nexus-password`
 * `server-id` (default: `ossrh`)
-* `maven-goals` (default: `clean deploy`)
+* `maven-goals` (default: `deploy`)
 * `maven-profiles` (default: `sign-source-javadoc`)
 * `working-directory` (default `.`)
 

--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,7 @@ inputs:
   maven-goals:
     description: Maven goals to run
     required: false
-    default: clean deploy
+    default: deploy
   maven-profiles:
     description: Maven profiles
     required: false


### PR DESCRIPTION
### 🤔 What's changed?

* Changed default for `maven-goals` parameter to only `deploy`

### ⚡️ What's your motivation? 

In https://github.com/cucumber/html-formatter/issues/65 we were surprised that the assets added in a previous build step had been removed before release.

There's no need to run this `clean` goal in CI before making a release.

### 🏷️ What kind of change is this?

- :boom: Breaking change (will cause existing user behaviour to not
  work it did before)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
